### PR TITLE
Credential leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib-cov
 *.pid
 *.gz
 .DS_Store
+.idea
 
 pids
 logs

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -42,7 +42,7 @@ module.exports = databases = (mongoose = require('mongoose')) ->
 
       finishOrRetry = (err, result) =>
         if err?
-          settings.logger?.error err, "Failed to connect to `#{url}` on startup - retrying in 5 sec"
+          settings.logger?.error err, "Failed to connect to `#{name}` on startup - retrying in 5 sec"
           setTimeout (-> connectTo name, settings), 5000
         else if @allConnected()
           callback() while callback = @callbacks.pop()

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -4,59 +4,102 @@ mongoose = require 'mongoose'
 manager = require('../lib/index')(mongoose)
 
 describe '::mongoose-manager', ->
-  connectionStub = (url, options, callback) ->
-    @readyState = 1
-    process.nextTick callback
-
-  beforeEach ->
-    sinon.stub(mongoose.Connection::, 'open', connectionStub)
-    sinon.stub(mongoose.Connection::, 'openSet', connectionStub)
-
-
-  describe 'a single server and replica set connection', ->
-    {singleServer, replicaSet} = {}
+  describe 'connect success', ->
+    connectionStub = (url, options, callback) ->
+      @readyState = 1
+      process.nextTick callback
 
     beforeEach ->
-      singleServer = 'mongodb://localhost'
-      replicaSet = 'mongodb://localhost,mongodb://another-server'
-      manager.create 'we-be-testin', { url: singleServer }
-      manager.create 'mo-testin', { url: replicaSet }
+      sinon.stub(mongoose.Connection::, 'open', connectionStub)
+      sinon.stub(mongoose.Connection::, 'openSet', connectionStub)
 
-    describe '.connect', ->
-      it 'calls callback on successful connection', (done) ->
+    describe 'a single server and replica set connection', ->
+      {singleServer, replicaSet} = {}
+
+      beforeEach ->
+        singleServer = 'mongodb://username:password@localhost'
+        replicaSet = 'mongodb://username:password@localhost,another-server'
+        manager.create 'we-be-testin', { url: singleServer }
+        manager.create 'mo-testin', { url: replicaSet }
+
+      describe '.connect', ->
+        it 'calls callback on successful connection', (done) ->
+          manager.connect done
+
+        it 'calls open for single urls', (done) ->
+          manager.connect ->
+            expect(mongoose.Connection::open.called).to.equal true
+            expect(mongoose.Connection::open.args[0][0]).to.equal singleServer
+            done()
+
+        it 'calls openSet for multiple urls', (done) ->
+          manager.connect ->
+            expect(mongoose.Connection::openSet.called).to.equal true
+            expect(mongoose.Connection::openSet.args[0][0]).to.equal replicaSet
+            done()
+
+    describe 'a connection set that already exists and is open', ->
+      beforeEach ->
+        manager.create 'we-be-testin', { url: 'mongodb://localhost' }
+        manager.connect()
+
+      it 'allows adding a second connection', (done) ->
+        manager.create 'mo-testin', { url: 'mongodb://localhosty' }
         manager.connect done
 
-      it 'calls open for single urls', (done) ->
-        manager.connect ->
-          expect(mongoose.Connection::open.called).to.equal true
-          expect(mongoose.Connection::open.args[0][0]).to.equal singleServer
-          done()
 
-      it 'calls openSet for multiple urls', (done) ->
-        manager.connect ->
-          expect(mongoose.Connection::openSet.called).to.equal true
-          expect(mongoose.Connection::openSet.args[0][0]).to.equal replicaSet
-          done()
+    describe 'a connection set that isn‘t open', ->
+      beforeEach ->
+        manager.create 'we-be-testin', { url: 'mongodb://localhost' }
 
+      it 'connects once despite attempts to open many times', (done) ->
+        manager.connect()
+        manager.connect done
 
-  describe 'a connection set that already exists and is open', ->
+      it 'calls callback immediately if everything is already open', (done) ->
+        manager.connect()
+        process.nextTick( -> manager.connect done )
+
+  describe 'a connect error', ->
+    {logger, username, password, databaseConfigName, connect, err} = {}
+
     beforeEach ->
-      manager.create 'we-be-testin', { url: 'mongodb://localhost' }
-      manager.connect()
+      logger = sinon.stub {error: (->), warn: (->), info: (->), debug: (->)}
+      username = 'someUsername'
+      password = 'somePassword'
+      databaseConfigName = 'someDatabase'
 
-    it 'allows adding a second connection', (done) ->
-      manager.create 'mo-testin', { url: 'mongodb://localhosty' }
-      manager.connect done
+      err = new Error('unable to connect')
 
+      sinon.stub(mongoose.Connection::, 'open')
 
-  describe 'a connection set that isn‘t open', ->
-    beforeEach ->
-      manager.create 'we-be-testin', { url: 'mongodb://localhost' }
+      url = "mongodb://#{username}:#{password}@localhost/db-name"
 
-    it 'connects once despite attempts to open many times', (done) ->
-      manager.connect()
-      manager.connect done
+      manager.create databaseConfigName, { url, logger }
 
-    it 'calls callback immediately if everything is already open', (done) ->
-      manager.connect()
-      process.nextTick( -> manager.connect done )
+      # tricky to stub out a failed open followed by a success which also mutates the connection state
+      connect = (cb) ->
+        manager.connect cb
+
+        connection = manager.connections[databaseConfigName]
+        expect(connection).to.be.ok()
+
+        # first return with an error
+        connection.open.yield(err)
+        # then return with success that also changes readyState
+        connection.readyState = 1
+        connection.open.yield()
+
+    it 'logs an error', (done) ->
+      connect ->
+        expect(logger.error.callCount).to.equal 1
+        expect(logger.error.firstCall.args[0]).to.equal err
+        expect(logger.error.firstCall.args[1]).to.contain(databaseConfigName)
+        done()
+
+    it 'does not leak credentials out to the logs', (done) ->
+      connect ->
+        expect(logger.error.callCount).to.equal 1
+        expect(logger.error.firstCall.args[1]).not.to.contain(username)
+        expect(logger.error.firstCall.args[1]).not.to.contain(password)
+        done()


### PR DESCRIPTION
Stop leaking mongo credentials embedded in the mongo url out to the logger on connection errors.