### PR TITLE
Fix openSet deprecation warning

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -54,10 +54,7 @@ module.exports = databases = (mongoose) ->
         else if @allConnected()
           callback() while callback = @callbacks.pop()
 
-      if url.indexOf(',') >= 0
-        @connections[name].openSet url, options, finishOrRetry
-      else
-        @connections[name].open url, options, finishOrRetry
+      @connections[name].openUri url, options, finishOrRetry
 
     for name, connection of @connections
       switch connection.readyState


### PR DESCRIPTION
Call `openUri` instead of `openSet` or `open`.

Note that this also requires changing the format of the options that are passed in - `socketOptions` is no longer supported, and sub-options have been moved up to the top level.

[#154655861]